### PR TITLE
iOS 9 compatibility

### DIFF
--- a/Classes/MainViewController.m
+++ b/Classes/MainViewController.m
@@ -199,6 +199,25 @@ void printInfo() {
 
 
 int getSignalStrength() {
+    
+    UIApplication *app = [UIApplication sharedApplication];
+    NSArray *subviews = [[[app valueForKey:@"statusBar"]     valueForKey:@"foregroundView"] subviews];
+    NSString *dataNetworkItemView = nil;
+    for (id subview in subviews) {
+        if([subview isKindOfClass:[NSClassFromString(@"UIStatusBarSignalStrengthItemView") class]])
+        {
+            dataNetworkItemView = subview;
+            break;
+        }
+    }
+    if (dataNetworkItemView){
+        int signalStrength = [[dataNetworkItemView valueForKey:@"signalStrengthRaw"] intValue];
+        NSLog(@"signal %d", signalStrength);
+        return signalStrength;
+    }
+    return 0;
+    
+    /*
 	void *libHandle = dlopen("/System/Library/Frameworks/CoreTelephony.framework/CoreTelephony", RTLD_LAZY);
 	int (*CTGetSignalStrength)();
 	CTGetSignalStrength = dlsym(libHandle, "CTGetSignalStrength");
@@ -206,5 +225,6 @@ int getSignalStrength() {
 	int result = CTGetSignalStrength();
 	dlclose(libHandle);	
 	return result;
+     */
 }
 

--- a/Classes/SignalLoggerAppDelegate.m
+++ b/Classes/SignalLoggerAppDelegate.m
@@ -24,7 +24,7 @@
     // Override point for customization after application launch.  
 
     // Add the main view controller's view to the window and display.
-    [window addSubview:mainViewController.view];
+    [window setRootViewController:mainViewController];
     [window makeKeyAndVisible];
 
     return YES;

--- a/LaunchScreen.xib
+++ b/LaunchScreen.xib
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1509" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+        </view>
+    </objects>
+</document>

--- a/SLlocationController.m
+++ b/SLlocationController.m
@@ -17,6 +17,7 @@
     self = [super init];
     if (self != nil) {
         self.locationManager = [[[CLLocationManager alloc] init] autorelease];
+        [self.locationManager requestAlwaysAuthorization];
         self.locationManager.delegate = self; // send loc updates to myself
     }
     return self;

--- a/SignalLogger-Info.plist
+++ b/SignalLogger-Info.plist
@@ -24,7 +24,27 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>We use your location</string>
+	<key>NSLocationUsageDescription</key>
+	<string>We use your location with your consent</string>
 	<key>NSMainNibFile</key>
 	<string>MainWindow</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
 </dict>
 </plist>

--- a/SignalLogger.xcodeproj/project.pbxproj
+++ b/SignalLogger.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B21AE25D131DD0280087FFD7 /* SLlocationController.m in Sources */ = {isa = PBXBuildFile; fileRef = B21AE25C131DD0280087FFD7 /* SLlocationController.m */; };
 		B21AE2D7131DE8D70087FFD7 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B21AE2D6131DE8D70087FFD7 /* MessageUI.framework */; };
 		B21AE312131E5FD00087FFD7 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B21AE311131E5FD00087FFD7 /* CoreTelephony.framework */; };
+		FAF83E4C1C398E9B00316F91 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAF83E4B1C398E9B00316F91 /* LaunchScreen.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +49,7 @@
 		B21AE2D6131DE8D70087FFD7 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		B21AE311131E5FD00087FFD7 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		B2F21B4C132661FA00D7F06F /* CoreTelephony.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreTelephony.h; sourceTree = "<group>"; };
+		FAF83E4B1C398E9B00316F91 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				280E754B0DD40C5E005A515E /* MainView.xib */,
 				280E754C0DD40C5E005A515E /* MainWindow.xib */,
 				8D1107310486CEB800E47090 /* SignalLogger-Info.plist */,
+				FAF83E4B1C398E9B00316F91 /* LaunchScreen.xib */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -188,6 +191,17 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				TargetAttributes = {
+					1D6058900D05DD3D006BFB54 = {
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
+					};
+				};
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "SignalLogger" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -213,6 +227,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAF83E4C1C398E9B00316F91 /* LaunchScreen.xib in Resources */,
 				280E754D0DD40C5E005A515E /* FlipsideView.xib in Resources */,
 				280E754E0DD40C5E005A515E /* MainView.xib in Resources */,
 				280E754F0DD40C5E005A515E /* MainWindow.xib in Resources */,
@@ -251,6 +266,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = SignalLogger_Prefix.pch;
 				INFOPLIST_FILE = "SignalLogger-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_NAME = SignalLogger;
 			};
 			name = Debug;
@@ -267,6 +283,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = SignalLogger_Prefix.pch;
 				INFOPLIST_FILE = "SignalLogger-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_NAME = SignalLogger;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/main.m
+++ b/main.m
@@ -7,11 +7,12 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "SignalLoggerAppDelegate.h"
 
 int main(int argc, char *argv[]) {
     
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, nil, nil);
+    int retVal = UIApplicationMain(argc, argv, nil, NSStringFromClass([SignalLoggerAppDelegate class]));
     [pool release];
     return retVal;
 }


### PR DESCRIPTION
This pull request brings following changes and improvements:
1) working way of getting signal strength for iOS 9 (works on devices only)
2) xib-based launch screen (otherwise app is not scaled to a device screen)
3) location authorization - iOS 9 needs that to get some location data
4) app startup fixes - using setRootViewController instead of addSubview and specify app delegate class name.

Data gathered with this app modification:
https://gist.github.com/alexsorokoletov/0ce68926804dee671563 (raw CSV)
https://www.dropbox.com/s/78ivw491nve0zk8/Screenshot%202016-01-04%2017.00.55.png?dl=0
